### PR TITLE
For Automatically creation of Payment Lines

### DIFF
--- a/sale_automatic_workflow/automatic_workflow_job.py
+++ b/sale_automatic_workflow/automatic_workflow_job.py
@@ -88,6 +88,7 @@ class automatic_workflow_job(orm.Model):
             with commit(cr):
                 wf_service.trg_validate(uid, 'sale.order',
                                         sale_id, 'order_confirm', cr)
+                sale_obj.browse(cr, uid, sale_id, context=context).action_button_confirm()
 
     def _reconcile_invoices(self, cr, uid, ids=None, context=None):
         invoice_obj = self.pool.get('account.invoice')


### PR DESCRIPTION
When ever Sale Order is got confirmed by Workflow, then Automatic Payment Lines are not get created for the Sale Order. So, to fix this issue, calling the action_button_confirm of SO from automatic workflow.